### PR TITLE
CSP-1004 puts member id in session

### DIFF
--- a/src/SFA.DAS.Employer.Aan.Domain/Interfaces/ISessionService.cs
+++ b/src/SFA.DAS.Employer.Aan.Domain/Interfaces/ISessionService.cs
@@ -2,7 +2,7 @@
 
 public interface ISessionService
 {
-    void Set(string value, string key);
+    void Set(string key, string value);
     void Set<T>(T model);
     string? Get(string key);
     T Get<T>();

--- a/src/SFA.DAS.Employer.Aan.Domain/Interfaces/ISessionService.cs
+++ b/src/SFA.DAS.Employer.Aan.Domain/Interfaces/ISessionService.cs
@@ -4,7 +4,7 @@ public interface ISessionService
 {
     void Set(string value, string key);
     void Set<T>(T model);
-    string Get(string key);
+    string? Get(string key);
     T Get<T>();
     void Delete(string key);
     void Delete<T>(T model);

--- a/src/SFA.DAS.Employer.Aan.Web.UnitTests/Controllers/ControllersTests.cs
+++ b/src/SFA.DAS.Employer.Aan.Web.UnitTests/Controllers/ControllersTests.cs
@@ -1,0 +1,32 @@
+﻿using System.Reflection;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using SFA.DAS.Employer.Aan.Web.Controllers;
+
+namespace SFA.DAS.Employer.Aan.Web.UnitTests.Controllers;
+
+public class ControllersTests
+{
+    private readonly List<string> _controllersThatDoNotRequireAuthorize = new List<string>()
+    {
+        nameof(ServiceController)
+    };
+
+    [Test]
+    public void Controllers_MustBeDecoratedWithAuthorizeAttribute()
+    {
+        var webAssembly = typeof(HomeController).GetTypeInfo().Assembly;
+
+        var controllers = webAssembly.DefinedTypes.Where(c => c.IsSubclassOf(typeof(ControllerBase))).ToList();
+
+        using (new AssertionScope())
+        {
+            foreach (var controller in controllers.Where(c => !_controllersThatDoNotRequireAuthorize.Contains(c.Name)))
+            {
+                controller.Should().BeDecoratedWith<AuthorizeAttribute>();
+            }
+        }
+    }
+}

--- a/src/SFA.DAS.Employer.Aan.Web.UnitTests/Controllers/EventsHubControllerTests.cs
+++ b/src/SFA.DAS.Employer.Aan.Web.UnitTests/Controllers/EventsHubControllerTests.cs
@@ -7,7 +7,6 @@ using SFA.DAS.Aan.SharedUi.Models;
 using SFA.DAS.Aan.SharedUi.OuterApi.Responses;
 using SFA.DAS.Employer.Aan.Domain.Interfaces;
 using SFA.DAS.Employer.Aan.Web.Controllers;
-using SFA.DAS.Employer.Aan.Web.Extensions;
 using SFA.DAS.Employer.Aan.Web.UnitTests.TestHelpers;
 
 namespace SFA.DAS.Employer.Aan.Web.UnitTests.Controllers;
@@ -36,9 +35,11 @@ public class EventsHubControllerTests
         _outerApiClientMock = new();
         _outerApiClientMock.Setup(o => o.GetAttendances(memberId, fromDate, toDate, _cancellationToken)).ReturnsAsync(attendances);
 
-        _sut = new(_outerApiClientMock.Object);
+        Mock<ISessionService> sessionServiceMock = new();
+        sessionServiceMock.Setup(s => s.Get(Constants.SessionKeys.MemberId)).Returns(memberId.ToString());
+
+        _sut = new(_outerApiClientMock.Object, sessionServiceMock.Object);
         _sut.AddUrlHelperMock().AddUrlForRoute(SharedRouteNames.NetworkEvents, AllNetworksUrl);
-        _sut.AddContextWithClaim(ClaimsPrincipalExtensions.ClaimTypes.AanMemberId, memberId.ToString());
 
         _result = await _sut.Index(accountId, null, null, _cancellationToken);
     }

--- a/src/SFA.DAS.Employer.Aan.Web.UnitTests/Controllers/HomeControllerTests.cs
+++ b/src/SFA.DAS.Employer.Aan.Web.UnitTests/Controllers/HomeControllerTests.cs
@@ -1,8 +1,9 @@
 ﻿using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
+using Moq;
+using SFA.DAS.Employer.Aan.Domain.Interfaces;
 using SFA.DAS.Employer.Aan.Web.Controllers;
 using SFA.DAS.Employer.Aan.Web.Infrastructure;
-using SFA.DAS.Employer.Aan.Web.UnitTests.TestHelpers;
 
 namespace SFA.DAS.Employer.Aan.Web.UnitTests.Controllers;
 
@@ -11,8 +12,9 @@ public class HomeControllerTests
     [Test]
     public void Index_IsNotMember_ReturnsBeforeYouStartPage()
     {
-        var controller = new HomeController();
-        controller.AddContextWithClaim("temp", "test");
+        Mock<ISessionService> sessionServiceMock = new();
+        sessionServiceMock.Setup(s => s.Get(Constants.SessionKeys.MemberId)).Returns(Guid.Empty.ToString());
+        var controller = new HomeController(sessionServiceMock.Object);
 
         var result = controller.Index(string.Empty);
 
@@ -23,8 +25,9 @@ public class HomeControllerTests
     [Test]
     public void Index_IsMember_ReturnsEventsHub()
     {
-        var controller = new HomeController();
-        controller.AddContextWithClaim(EmployerClaims.AanMemberId, "test");
+        Mock<ISessionService> sessionServiceMock = new();
+        sessionServiceMock.Setup(s => s.Get(Constants.SessionKeys.MemberId)).Returns(Guid.NewGuid().ToString());
+        var controller = new HomeController(sessionServiceMock.Object);
 
         var result = controller.Index(string.Empty);
 

--- a/src/SFA.DAS.Employer.Aan.Web.UnitTests/Controllers/NetworkEventDetailsControllerTests.cs
+++ b/src/SFA.DAS.Employer.Aan.Web.UnitTests/Controllers/NetworkEventDetailsControllerTests.cs
@@ -12,6 +12,7 @@ using SFA.DAS.ApprenticeAan.Web.Models.NetworkEvents;
 using SFA.DAS.Employer.Aan.Domain.Interfaces;
 using SFA.DAS.Employer.Aan.Domain.OuterApi.Requests;
 using SFA.DAS.Employer.Aan.Web.Controllers;
+using SFA.DAS.Employer.Aan.Web.Infrastructure;
 using SFA.DAS.Employer.Aan.Web.UnitTests.TestHelpers;
 using SFA.DAS.Testing.AutoFixture;
 
@@ -190,7 +191,7 @@ public class NetworkEventDetailsControllerTests
         };
         var result = await sut.Post(accountId, command, new CancellationToken());
 
-        Assert.That(result.As<RedirectToActionResult>().ActionName, Is.EqualTo("SignUpConfirmation"));
+        Assert.That(result.As<RedirectToRouteResult>().RouteName, Is.EqualTo(RouteNames.AttendanceConfirmations.SignUpConfirmation));
     }
 
     [Test, MoqAutoData]
@@ -209,6 +210,6 @@ public class NetworkEventDetailsControllerTests
         };
         var result = await sut.Post(accountId, command, new CancellationToken());
 
-        Assert.That(result.As<RedirectToActionResult>().ActionName, Is.EqualTo("CancellationConfirmation"));
+        Assert.That(result.As<RedirectToRouteResult>().RouteName, Is.EqualTo(RouteNames.AttendanceConfirmations.CancellationConfirmation));
     }
 }

--- a/src/SFA.DAS.Employer.Aan.Web.UnitTests/Controllers/Onboarding/CheckYourAnswersControllerTests/CheckYourAnswersControllerPostTests.cs
+++ b/src/SFA.DAS.Employer.Aan.Web.UnitTests/Controllers/Onboarding/CheckYourAnswersControllerTests/CheckYourAnswersControllerPostTests.cs
@@ -68,7 +68,7 @@ public class CheckYourAnswersControllerPostTests
             r.OrganisationName == user.GetEmployerAccount(employerAccountId).DasAccountName
             && r.JoinedDate.Date == DateTime.UtcNow.Date
             && r.AccountId == onboardingSessionModel.EmployerDetails.AccountId
-            && r.UserRef == user.GetIdamsUserId()
+            && r.UserRef == user.GetUserId()
             && r.RegionId == (onboardingSessionModel.IsMultiRegionalOrganisation.GetValueOrDefault() ? null : onboardingSessionModel.Regions.Find(x => x.IsConfirmed)!.Id)
             && r.Email == user.GetEmail()
             && r.FirstName == user.GetGivenName()

--- a/src/SFA.DAS.Employer.Aan.Web.UnitTests/TestHelpers/ControllerExtensions.cs
+++ b/src/SFA.DAS.Employer.Aan.Web.UnitTests/TestHelpers/ControllerExtensions.cs
@@ -2,9 +2,7 @@
 using AutoFixture;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Routing;
-using Microsoft.AspNetCore.Routing;
 using Moq;
 using Newtonsoft.Json;
 using SFA.DAS.Employer.Aan.Domain.OuterApi.Responses;
@@ -27,14 +25,6 @@ public static class ControllerExtensions
            .Setup(m => m.RouteUrl(It.Is<UrlRouteContext>(c => c.RouteName!.Equals(routeName))))
            .Returns(url);
         return urlHelperMock;
-    }
-
-    public static void AddContextWithClaim(this Controller controller, string claimType, string claimValue)
-    {
-        var httpContext = new Mock<HttpContext>();
-        Claim claim = new(claimType, claimValue);
-        httpContext.Setup(m => m.User.FindFirst(claimType)).Returns(claim);
-        controller.ControllerContext = new(new ActionContext(httpContext.Object, new RouteData(), new ControllerActionDescriptor()));
     }
 
     public static void AddDefaultContext(this Controller controller)

--- a/src/SFA.DAS.Employer.Aan.Web.UnitTests/TestHelpers/UsersForTesting.cs
+++ b/src/SFA.DAS.Employer.Aan.Web.UnitTests/TestHelpers/UsersForTesting.cs
@@ -13,10 +13,10 @@ public static class UsersForTesting
         var givenName = "validGivenName";
         var familyNameClaim = new Claim(EmployerClaims.FamilyName, familyName);
         var givenNameClaim = new Claim(EmployerClaims.GivenName, givenName);
-        var nameClaim = new Claim(EmployerClaims.IdamsUserDisplayNameClaimTypeIdentifier, $"{givenName} {familyName}");
+        var nameClaim = new Claim(EmployerClaims.UserDisplayNameClaimTypeIdentifier, $"{givenName} {familyName}");
 
         var emailClaim = new Claim(ClaimTypes.Email, "valid_email");
-        var userIdClaimTypeIdentifier = new Claim(EmployerClaims.IdamsUserIdClaimTypeIdentifier, Guid.NewGuid().ToString());
+        var userIdClaimTypeIdentifier = new Claim(EmployerClaims.UserIdClaimTypeIdentifier, Guid.NewGuid().ToString());
 
         EmployerUserAccountItem employerIdentifier = new(employerAccountId.ToString().ToUpper(), "das_account_name", "role");
         var employerAccounts = new Dictionary<string, EmployerUserAccountItem> { { employerIdentifier.EncodedAccountId, employerIdentifier } };

--- a/src/SFA.DAS.Employer.Aan.Web/Authentication/EmployerAccountPostAuthenticationClaimsHandler.cs
+++ b/src/SFA.DAS.Employer.Aan.Web/Authentication/EmployerAccountPostAuthenticationClaimsHandler.cs
@@ -42,11 +42,11 @@ public class EmployerAccountPostAuthenticationClaimsHandler : ICustomClaims
         {
             claims.Add(new Claim(EmployerClaims.GivenName, result.FirstName));
             claims.Add(new Claim(EmployerClaims.FamilyName, result.LastName));
-            claims.Add(new Claim(EmployerClaims.IdamsUserDisplayNameClaimTypeIdentifier, result.FirstName + " " + result.LastName));
+            claims.Add(new Claim(EmployerClaims.UserDisplayNameClaimTypeIdentifier, result.FirstName + " " + result.LastName));
         }
 
-        claims.Add(new Claim(EmployerClaims.IdamsUserIdClaimTypeIdentifier, result.EmployerUserId));
-        claims.Add(new Claim(EmployerClaims.IdamsUserEmailClaimTypeIdentifier, email!));
+        claims.Add(new Claim(EmployerClaims.UserIdClaimTypeIdentifier, result.EmployerUserId));
+        claims.Add(new Claim(EmployerClaims.UserEmailClaimTypeIdentifier, email!));
 
         result.UserAccountResponse
             .Where(c => c.Role.Equals("owner", StringComparison.CurrentCultureIgnoreCase) || c.Role.Equals("transactor", StringComparison.CurrentCultureIgnoreCase))

--- a/src/SFA.DAS.Employer.Aan.Web/Authentication/EmployerAccountPostAuthenticationClaimsHandler.cs
+++ b/src/SFA.DAS.Employer.Aan.Web/Authentication/EmployerAccountPostAuthenticationClaimsHandler.cs
@@ -54,12 +54,6 @@ public class EmployerAccountPostAuthenticationClaimsHandler : ICustomClaims
 
         claims.Add(associatedAccountsClaim);
 
-        if (Guid.TryParse(userId, out var id))
-        {
-            var response = await _outerApiClient.GetEmployerMember(id, CancellationToken.None);
-            if (response.ResponseMessage.IsSuccessStatusCode) claims.Add(new Claim(EmployerClaims.AanMemberId, response.GetContent().MemberId.ToString()));
-        }
-
         return claims;
     }
 }

--- a/src/SFA.DAS.Employer.Aan.Web/Constants.cs
+++ b/src/SFA.DAS.Employer.Aan.Web/Constants.cs
@@ -1,0 +1,9 @@
+﻿namespace SFA.DAS.Employer.Aan.Web;
+
+public static class Constants
+{
+    public static class SessionKeys
+    {
+        public const string MemberId = nameof(MemberId);
+    }
+}

--- a/src/SFA.DAS.Employer.Aan.Web/Controllers/AccessDeniedController.cs
+++ b/src/SFA.DAS.Employer.Aan.Web/Controllers/AccessDeniedController.cs
@@ -1,10 +1,11 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using SFA.DAS.Employer.Aan.Web.Authentication;
 
 namespace SFA.DAS.Employer.Aan.Web.Controllers;
 
-[AllowAnonymous]
+[Authorize(Policy = nameof(PolicyNames.HasEmployerAccount))]
 [Route("accounts/{employerAccountId}/accessdenied")]
 [ExcludeFromCodeCoverage]
 public class AccessDeniedController : Controller

--- a/src/SFA.DAS.Employer.Aan.Web/Controllers/EventsHubController.cs
+++ b/src/SFA.DAS.Employer.Aan.Web/Controllers/EventsHubController.cs
@@ -1,13 +1,16 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.Aan.SharedUi.Extensions;
 using SFA.DAS.Aan.SharedUi.Models;
 using SFA.DAS.Aan.SharedUi.OuterApi.Responses;
 using SFA.DAS.Employer.Aan.Domain.Interfaces;
+using SFA.DAS.Employer.Aan.Web.Authentication;
 using SFA.DAS.Employer.Aan.Web.Extensions;
 using SFA.DAS.Employer.Aan.Web.Infrastructure;
 
 namespace SFA.DAS.Employer.Aan.Web.Controllers;
 
+[Authorize(Policy = nameof(PolicyNames.HasEmployerAccount))]
 [Route("accounts/{employerAccountId}/events-hub", Name = RouteNames.EventsHub)]
 public class EventsHubController : Controller
 {

--- a/src/SFA.DAS.Employer.Aan.Web/Controllers/HomeController.cs
+++ b/src/SFA.DAS.Employer.Aan.Web/Controllers/HomeController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using SFA.DAS.Employer.Aan.Domain.Interfaces;
 using SFA.DAS.Employer.Aan.Web.Authentication;
 using SFA.DAS.Employer.Aan.Web.Infrastructure;
 
@@ -9,10 +10,17 @@ namespace SFA.DAS.Employer.Aan.Web.Controllers;
 [Route("accounts/{employerAccountId}", Name = RouteNames.Home)]
 public class HomeController : Controller
 {
+    private readonly ISessionService _sessionService;
+
+    public HomeController(ISessionService sessionService)
+    {
+        _sessionService = sessionService;
+    }
+
     public IActionResult Index([FromRoute] string employerAccountId)
     {
-        var claim = User.FindFirst(EmployerClaims.AanMemberId);
-        return claim == null
+        var memberId = Guid.Parse(_sessionService.Get(Constants.SessionKeys.MemberId)!);
+        return memberId == Guid.Empty
             ? new RedirectToRouteResult(RouteNames.Onboarding.BeforeYouStart, new { EmployerAccountId = employerAccountId })
             : new RedirectToRouteResult(RouteNames.NetworkHub, new { EmployerAccountId = employerAccountId });
     }

--- a/src/SFA.DAS.Employer.Aan.Web/Controllers/NetworkEventDetailsController.cs
+++ b/src/SFA.DAS.Employer.Aan.Web/Controllers/NetworkEventDetailsController.cs
@@ -1,15 +1,18 @@
 ﻿using FluentValidation;
 using FluentValidation.AspNetCore;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.Aan.SharedUi.Infrastructure;
 using SFA.DAS.Aan.SharedUi.Models;
 using SFA.DAS.ApprenticeAan.Web.Models.NetworkEvents;
 using SFA.DAS.Employer.Aan.Domain.Interfaces;
 using SFA.DAS.Employer.Aan.Domain.OuterApi.Requests;
+using SFA.DAS.Employer.Aan.Web.Authentication;
 using SFA.DAS.Employer.Aan.Web.Infrastructure;
 
 namespace SFA.DAS.Employer.Aan.Web.Controllers;
 
+[Authorize(Policy = nameof(PolicyNames.HasEmployerAccount))]
 public class NetworkEventDetailsController : Controller
 {
     public const string DetailsViewPath = "~/Views/NetworkEventDetails/Detail.cshtml";

--- a/src/SFA.DAS.Employer.Aan.Web/Controllers/NetworkEventDetailsController.cs
+++ b/src/SFA.DAS.Employer.Aan.Web/Controllers/NetworkEventDetailsController.cs
@@ -71,25 +71,26 @@ public class NetworkEventDetailsController : Controller
 
         await _outerApiClient.PutAttendance(command.CalendarEventId, memberId, new SetAttendanceStatusRequest(command.NewStatus), cancellationToken);
 
+        var routeValues = new { employerAccountId, id = command.CalendarEventId };
         return command.NewStatus
-            ? RedirectToAction("SignUpConfirmation", new { employerAccountId = employerAccountId })
-            : RedirectToAction("CancellationConfirmation", new { employerAccountId = employerAccountId });
+            ? RedirectToRoute(RouteNames.AttendanceConfirmations.SignUpConfirmation, routeValues)
+            : RedirectToRoute(RouteNames.AttendanceConfirmations.CancellationConfirmation, routeValues);
     }
 
 
     [HttpGet]
-    [Route("signup-confirmation", Name = RouteNames.AttendanceConfirmations.SignUpConfirmation)]
-    public IActionResult SignUpConfirmation(string employerAccountId)
+    [Route("accounts/{employerAccountId}/network-events/{id}/signup-confirmation", Name = RouteNames.AttendanceConfirmations.SignUpConfirmation)]
+    public IActionResult SignUpConfirmation([FromRoute] string employerAccountId)
     {
-        EventAttendanceConfirmationViewModel model = new(Url.RouteUrl(SharedRouteNames.NetworkEvents, new { employerAccountId = employerAccountId })!, new(Url.RouteUrl(SharedRouteNames.EventsHub, new { employerAccountId = employerAccountId })));
+        EventAttendanceConfirmationViewModel model = new(Url.RouteUrl(SharedRouteNames.NetworkEvents, new { employerAccountId = employerAccountId })!, new(Url.RouteUrl(SharedRouteNames.EventsHub, new { employerAccountId })));
         return View(SignUpConfirmationViewPath, model);
     }
 
     [HttpGet]
-    [Route("cancellation-confirmation", Name = RouteNames.AttendanceConfirmations.CancellationConfirmation)]
-    public IActionResult CancellationConfirmation(string employerAccountId)
+    [Route("accounts/{employerAccountId}/network-events/{id}/cancellation-confirmation", Name = RouteNames.AttendanceConfirmations.CancellationConfirmation)]
+    public IActionResult CancellationConfirmation([FromRoute] string employerAccountId)
     {
-        EventAttendanceConfirmationViewModel model = new(Url.RouteUrl(SharedRouteNames.NetworkEvents, new { employerAccountId = employerAccountId })!, new(Url.RouteUrl(SharedRouteNames.EventsHub, new { employerAccountId = employerAccountId })));
+        EventAttendanceConfirmationViewModel model = new(Url.RouteUrl(SharedRouteNames.NetworkEvents, new { employerAccountId = employerAccountId })!, new(Url.RouteUrl(SharedRouteNames.EventsHub, new { employerAccountId })));
         return View(CancellationConfirmationViewPath, model);
     }
 }

--- a/src/SFA.DAS.Employer.Aan.Web/Controllers/NetworkEventsController.cs
+++ b/src/SFA.DAS.Employer.Aan.Web/Controllers/NetworkEventsController.cs
@@ -9,7 +9,6 @@ using SFA.DAS.ApprenticeAan.Web.Models.NetworkEvents;
 using SFA.DAS.ApprenticeAan.Web.Services;
 using SFA.DAS.Employer.Aan.Domain.Interfaces;
 using SFA.DAS.Employer.Aan.Domain.OuterApi.Responses;
-using SFA.DAS.Employer.Aan.Web.Extensions;
 using SFA.DAS.Employer.Aan.Web.Infrastructure;
 
 namespace SFA.DAS.Employer.Aan.Web.Controllers;
@@ -18,16 +17,19 @@ namespace SFA.DAS.Employer.Aan.Web.Controllers;
 public class NetworkEventsController : Controller
 {
     private readonly IOuterApiClient _outerApiClient;
+    private readonly ISessionService _sessionService;
 
-    public NetworkEventsController(IOuterApiClient outerApiClient)
+    public NetworkEventsController(IOuterApiClient outerApiClient, ISessionService sessionService)
     {
         _outerApiClient = outerApiClient;
+        _sessionService = sessionService;
     }
 
     [HttpGet]
     public async Task<IActionResult> Index([FromRoute] string employerAccountId, GetNetworkEventsRequest request, CancellationToken cancellationToken)
     {
-        var calendarEventsTask = _outerApiClient.GetCalendarEvents(User.GetAanMemberId(), QueryStringParameterBuilder.BuildQueryStringParameters(request), cancellationToken);
+        var memberId = Guid.Parse(_sessionService.Get(Constants.SessionKeys.MemberId)!);
+        var calendarEventsTask = _outerApiClient.GetCalendarEvents(memberId, QueryStringParameterBuilder.BuildQueryStringParameters(request), cancellationToken);
         var calendarTask = _outerApiClient.GetCalendars(cancellationToken);
         var regionTask = _outerApiClient.GetRegions(cancellationToken);
 

--- a/src/SFA.DAS.Employer.Aan.Web/Controllers/NetworkEventsController.cs
+++ b/src/SFA.DAS.Employer.Aan.Web/Controllers/NetworkEventsController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.Aan.SharedUi.Constants;
 using SFA.DAS.Aan.SharedUi.Extensions;
 using SFA.DAS.Aan.SharedUi.Infrastructure;
@@ -9,10 +10,12 @@ using SFA.DAS.ApprenticeAan.Web.Models.NetworkEvents;
 using SFA.DAS.ApprenticeAan.Web.Services;
 using SFA.DAS.Employer.Aan.Domain.Interfaces;
 using SFA.DAS.Employer.Aan.Domain.OuterApi.Responses;
+using SFA.DAS.Employer.Aan.Web.Authentication;
 using SFA.DAS.Employer.Aan.Web.Infrastructure;
 
 namespace SFA.DAS.Employer.Aan.Web.Controllers;
 
+[Authorize(Policy = nameof(PolicyNames.HasEmployerAccount))]
 [Route("accounts/{employerAccountId}/network-events", Name = RouteNames.NetworkEvents)]
 public class NetworkEventsController : Controller
 {

--- a/src/SFA.DAS.Employer.Aan.Web/Controllers/Onboarding/AreasToEngageLocallyController.cs
+++ b/src/SFA.DAS.Employer.Aan.Web/Controllers/Onboarding/AreasToEngageLocallyController.cs
@@ -1,13 +1,16 @@
 ﻿using FluentValidation;
 using FluentValidation.AspNetCore;
 using FluentValidation.Results;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.Employer.Aan.Domain.Interfaces;
+using SFA.DAS.Employer.Aan.Web.Authentication;
 using SFA.DAS.Employer.Aan.Web.Infrastructure;
 using SFA.DAS.Employer.Aan.Web.Models.Onboarding;
 
 namespace SFA.DAS.Employer.Aan.Web.Controllers.Onboarding;
 
+[Authorize(Policy = nameof(PolicyNames.HasEmployerAccount))]
 [Route("accounts/{employerAccountId}/onboarding/areas-to-engage-locally", Name = RouteNames.Onboarding.AreasToEngageLocally)]
 public class AreasToEngageLocallyController : Controller
 {

--- a/src/SFA.DAS.Employer.Aan.Web/Controllers/Onboarding/CheckYourAnswersController.cs
+++ b/src/SFA.DAS.Employer.Aan.Web/Controllers/Onboarding/CheckYourAnswersController.cs
@@ -60,7 +60,7 @@ public class CheckYourAnswersController : Controller
         }
         var response = await _outerApiClient.PostEmployerMember(PopulateCreateEmployerMemberRequest(sessionModel, employerAccountId), cancellationToken);
 
-        User.AddAanMemberIdClaim(response.MemberId);
+        _sessionService.Set(Constants.SessionKeys.MemberId, response.MemberId.ToString());
 
         return View(ApplicationSubmittedViewPath, new ApplicationSubmittedViewModel(Url.RouteUrl(@RouteNames.NetworkHub, new { EmployerAccountId = employerAccountId })!));
     }

--- a/src/SFA.DAS.Employer.Aan.Web/Controllers/Onboarding/CheckYourAnswersController.cs
+++ b/src/SFA.DAS.Employer.Aan.Web/Controllers/Onboarding/CheckYourAnswersController.cs
@@ -1,15 +1,18 @@
 ﻿using FluentValidation;
 using FluentValidation.AspNetCore;
 using FluentValidation.Results;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.Employer.Aan.Domain.Interfaces;
 using SFA.DAS.Employer.Aan.Domain.OuterApi.Requests;
+using SFA.DAS.Employer.Aan.Web.Authentication;
 using SFA.DAS.Employer.Aan.Web.Extensions;
 using SFA.DAS.Employer.Aan.Web.Infrastructure;
 using SFA.DAS.Employer.Aan.Web.Models.Onboarding;
 
 namespace SFA.DAS.Employer.Aan.Web.Controllers.Onboarding;
 
+[Authorize(Policy = nameof(PolicyNames.HasEmployerAccount))]
 [Route("accounts/{employerAccountId}/onboarding/check-your-answers", Name = RouteNames.Onboarding.CheckYourAnswers)]
 public class CheckYourAnswersController : Controller
 {

--- a/src/SFA.DAS.Employer.Aan.Web/Controllers/Onboarding/CheckYourAnswersController.cs
+++ b/src/SFA.DAS.Employer.Aan.Web/Controllers/Onboarding/CheckYourAnswersController.cs
@@ -40,7 +40,7 @@ public class CheckYourAnswersController : Controller
     private CheckYourAnswersViewModel GetViewModel(OnboardingSessionModel sessionModel, string employerAccountId)
     {
         var viewModel = new CheckYourAnswersViewModel(Url, sessionModel, employerAccountId);
-        viewModel.FullName = User.GetIdamsUserDisplayName();
+        viewModel.FullName = User.GetUserDisplayName();
         viewModel.Email = User.GetEmail();
         return viewModel;
     }
@@ -77,7 +77,7 @@ public class CheckYourAnswersController : Controller
         request.Email = User.GetEmail();
         request.FirstName = User.GetGivenName();
         request.LastName = User.GetFamilyName();
-        request.UserRef = User.GetIdamsUserId();
+        request.UserRef = User.GetUserId();
         request.AccountId = source.EmployerDetails.AccountId;
 
         return request;

--- a/src/SFA.DAS.Employer.Aan.Web/Controllers/Onboarding/JoinTheNetworkController.cs
+++ b/src/SFA.DAS.Employer.Aan.Web/Controllers/Onboarding/JoinTheNetworkController.cs
@@ -1,15 +1,18 @@
 ﻿using FluentValidation;
 using FluentValidation.AspNetCore;
 using FluentValidation.Results;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.Employer.Aan.Domain.Constants;
 using SFA.DAS.Employer.Aan.Domain.Interfaces;
+using SFA.DAS.Employer.Aan.Web.Authentication;
 using SFA.DAS.Employer.Aan.Web.Infrastructure;
 using SFA.DAS.Employer.Aan.Web.Models;
 using SFA.DAS.Employer.Aan.Web.Models.Onboarding;
 
 namespace SFA.DAS.Employer.Aan.Web.Controllers.Onboarding;
 
+[Authorize(Policy = nameof(PolicyNames.HasEmployerAccount))]
 [Route("accounts/{employerAccountId}/onboarding/reason-to-join", Name = RouteNames.Onboarding.JoinTheNetwork)]
 public class JoinTheNetworkController : Controller
 {

--- a/src/SFA.DAS.Employer.Aan.Web/Controllers/Onboarding/PreviousEngagementController.cs
+++ b/src/SFA.DAS.Employer.Aan.Web/Controllers/Onboarding/PreviousEngagementController.cs
@@ -1,9 +1,11 @@
 ﻿using FluentValidation;
 using FluentValidation.AspNetCore;
 using FluentValidation.Results;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.Employer.Aan.Domain.Constants;
 using SFA.DAS.Employer.Aan.Domain.Interfaces;
+using SFA.DAS.Employer.Aan.Web.Authentication;
 using SFA.DAS.Employer.Aan.Web.Extensions;
 using SFA.DAS.Employer.Aan.Web.Infrastructure;
 using SFA.DAS.Employer.Aan.Web.Models.Onboarding;
@@ -11,6 +13,7 @@ using SFA.DAS.Encoding;
 
 namespace SFA.DAS.Employer.Aan.Web.Controllers.Onboarding;
 
+[Authorize(Policy = nameof(PolicyNames.HasEmployerAccount))]
 [Route("accounts/{employerAccountId}/onboarding/previous-engagement", Name = RouteNames.Onboarding.PreviousEngagement)]
 public class PreviousEngagementController : Controller
 {

--- a/src/SFA.DAS.Employer.Aan.Web/Controllers/Onboarding/PrimaryEngagementWithinNetworkController.cs
+++ b/src/SFA.DAS.Employer.Aan.Web/Controllers/Onboarding/PrimaryEngagementWithinNetworkController.cs
@@ -1,13 +1,16 @@
 ﻿using FluentValidation;
 using FluentValidation.AspNetCore;
 using FluentValidation.Results;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.Employer.Aan.Domain.Interfaces;
+using SFA.DAS.Employer.Aan.Web.Authentication;
 using SFA.DAS.Employer.Aan.Web.Infrastructure;
 using SFA.DAS.Employer.Aan.Web.Models.Onboarding;
 
 namespace SFA.DAS.Employer.Aan.Web.Controllers.Onboarding;
 
+[Authorize(Policy = nameof(PolicyNames.HasEmployerAccount))]
 [Route("accounts/{employerAccountId}/onboarding/primary-engagement", Name = RouteNames.Onboarding.PrimaryEngagementWithinNetwork)]
 public class PrimaryEngagementWithinNetworkController : Controller
 {

--- a/src/SFA.DAS.Employer.Aan.Web/Controllers/Onboarding/RegionsController.cs
+++ b/src/SFA.DAS.Employer.Aan.Web/Controllers/Onboarding/RegionsController.cs
@@ -1,14 +1,17 @@
 ﻿using FluentValidation;
 using FluentValidation.AspNetCore;
 using FluentValidation.Results;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.Employer.Aan.Domain.Interfaces;
+using SFA.DAS.Employer.Aan.Web.Authentication;
 using SFA.DAS.Employer.Aan.Web.Infrastructure;
 using SFA.DAS.Employer.Aan.Web.Models;
 using SFA.DAS.Employer.Aan.Web.Models.Onboarding;
 
 namespace SFA.DAS.Employer.Aan.Web.Controllers.Onboarding;
 
+[Authorize(Policy = nameof(PolicyNames.HasEmployerAccount))]
 [Route("accounts/{employerAccountId}/onboarding/regions", Name = RouteNames.Onboarding.Regions)]
 public class RegionsController : Controller
 {

--- a/src/SFA.DAS.Employer.Aan.Web/Controllers/ServiceController.cs
+++ b/src/SFA.DAS.Employer.Aan.Web/Controllers/ServiceController.cs
@@ -78,7 +78,7 @@ public class ServiceController : Controller
     [Route("account-details", Name = RouteNames.StubAccountDetailsPost)]
     public async Task<IActionResult> AccountDetails(StubAuthenticationViewModel model)
     {
-        
+
         var claims = await _stubAuthenticationService.GetStubSignInClaims(model);
 
         await HttpContext.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, claims,
@@ -107,6 +107,3 @@ public class ServiceController : Controller
     }
 #endif
 }
-
-
-

--- a/src/SFA.DAS.Employer.Aan.Web/Extensions/ClaimsPrincipalExtensions.cs
+++ b/src/SFA.DAS.Employer.Aan.Web/Extensions/ClaimsPrincipalExtensions.cs
@@ -11,17 +11,10 @@ public static class ClaimsPrincipalExtensions
 {
     public static class ClaimTypes
     {
-        public const string AanMemberId = "http://das/employer/identity/claims/aan_member_id";
-        public const string StagedEmployer = "is_staged_employer";
         //This is defined in the login service, so it should be exact match
+        public const string StagedEmployer = "is_staged_employer";
         public const string EmployerId = "employer_id";
     }
-    public static void AddAanMemberIdClaim(this ClaimsPrincipal principal, Guid memberId)
-    {
-        principal.AddIdentity(new ClaimsIdentity(new[] { new Claim(ClaimTypes.AanMemberId, memberId.ToString()) }));
-    }
-
-    public static Guid GetAanMemberId(this ClaimsPrincipal principal) => GetClaimValue(principal, ClaimTypes.AanMemberId);
 
     private static Guid GetClaimValue(ClaimsPrincipal principal, string claimType)
     {

--- a/src/SFA.DAS.Employer.Aan.Web/Extensions/ClaimsPrincipalExtensions.cs
+++ b/src/SFA.DAS.Employer.Aan.Web/Extensions/ClaimsPrincipalExtensions.cs
@@ -40,9 +40,9 @@ public static class ClaimsPrincipalExtensions
 
     public static EmployerUserAccountItem GetEmployerAccount(this ClaimsPrincipal user, string employerAccountId)
         => GetEmployerAccounts(user)[employerAccountId.ToUpper()];
-    public static Guid GetIdamsUserId(this ClaimsPrincipal principal) => GetClaimValue(principal, EmployerClaims.IdamsUserIdClaimTypeIdentifier);
-    public static string GetIdamsUserDisplayName(this ClaimsPrincipal principal) => principal.FindFirstValue(EmployerClaims.IdamsUserDisplayNameClaimTypeIdentifier);
+    public static Guid GetUserId(this ClaimsPrincipal principal) => GetClaimValue(principal, EmployerClaims.UserIdClaimTypeIdentifier);
+    public static string GetUserDisplayName(this ClaimsPrincipal principal) => principal.FindFirstValue(EmployerClaims.UserDisplayNameClaimTypeIdentifier);
     public static string GetGivenName(this ClaimsPrincipal principal) => principal.FindFirstValue(EmployerClaims.GivenName);
     public static string GetFamilyName(this ClaimsPrincipal principal) => principal.FindFirstValue(EmployerClaims.FamilyName);
-    public static string GetEmail(this ClaimsPrincipal principal) => principal.FindFirstValue(EmployerClaims.IdamsUserEmailClaimTypeIdentifier);
+    public static string GetEmail(this ClaimsPrincipal principal) => principal.FindFirstValue(EmployerClaims.UserEmailClaimTypeIdentifier);
 }

--- a/src/SFA.DAS.Employer.Aan.Web/Filters/RequiredSessionModelAttribute.cs
+++ b/src/SFA.DAS.Employer.Aan.Web/Filters/RequiredSessionModelAttribute.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Filters;
 using SFA.DAS.Employer.Aan.Domain.Interfaces;
@@ -9,7 +8,7 @@ using SFA.DAS.Employer.Aan.Web.Models.Onboarding;
 namespace SFA.DAS.Employer.Aan.Web.Filters;
 
 [ExcludeFromCodeCoverage]
-public class RequiredSessionModelAttribute : ActionFilterAttribute
+public class RequiredSessionModelAttribute : ApplicationFilterAttribute
 {
     const string DefaultActionName = "Index";
     const string DefaultControllerName = "Home";
@@ -27,7 +26,7 @@ public class RequiredSessionModelAttribute : ActionFilterAttribute
 
         if (!HasValidSessionModel(context.HttpContext.RequestServices))
         {
-            context.Result = RedirectToHome;
+            context.Result = RedirectToHome(context.RouteData.Values);
         }
     }
 
@@ -39,7 +38,6 @@ public class RequiredSessionModelAttribute : ActionFilterAttribute
 
         return false;
     }
-    private static bool IsRequestForOnboardingAction(ControllerActionDescriptor action) => action.ControllerTypeInfo.FullName!.Contains(OnboardingFilter);
 
     private static bool HasValidSessionModel(IServiceProvider services)
     {
@@ -49,6 +47,4 @@ public class RequiredSessionModelAttribute : ActionFilterAttribute
 
         return sessionModel != null && sessionModel.IsValid;
     }
-
-    private readonly static RedirectToActionResult RedirectToHome = new(DefaultActionName, DefaultControllerName, null);
 }

--- a/src/SFA.DAS.Employer.Aan.Web/Filters/RequiredSessionModelAttribute.cs
+++ b/src/SFA.DAS.Employer.Aan.Web/Filters/RequiredSessionModelAttribute.cs
@@ -10,10 +10,6 @@ namespace SFA.DAS.Employer.Aan.Web.Filters;
 [ExcludeFromCodeCoverage]
 public class RequiredSessionModelAttribute : ApplicationFilterAttribute
 {
-    const string DefaultActionName = "Index";
-    const string DefaultControllerName = "Home";
-    const string OnboardingFilter = "Onboarding";
-
     private static readonly string[] controllersToByPass = new[] { nameof(BeforeYouStartController), nameof(TermsAndConditionsController) };
 
     public string[] ControllersToByPass { get => controllersToByPass; }

--- a/src/SFA.DAS.Employer.Aan.Web/Filters/RequiresExistingMemberAttribute.cs
+++ b/src/SFA.DAS.Employer.Aan.Web/Filters/RequiresExistingMemberAttribute.cs
@@ -43,10 +43,13 @@ public class RequiresExistingMemberAttribute : ApplicationFilterAttribute
 
     private async Task<bool> IsValidRequest(ActionExecutingContext context, ControllerActionDescriptor controllerActionDescriptor)
     {
+        var userId = context.HttpContext.User.GetUserId();
+        if (userId == Guid.Empty) return true;
+
         var sessionValue = _sessionService.Get(Constants.SessionKeys.MemberId);
         if (sessionValue == null)
         {
-            var response = await _outerApiClient.GetEmployerMember(context.HttpContext.User.GetUserId(), CancellationToken.None);
+            var response = await _outerApiClient.GetEmployerMember(userId, CancellationToken.None);
             sessionValue = response.ResponseMessage.IsSuccessStatusCode ? response.GetContent().MemberId.ToString() : Guid.Empty.ToString();
             _sessionService.Set(Constants.SessionKeys.MemberId, sessionValue);
         }

--- a/src/SFA.DAS.Employer.Aan.Web/Filters/RequiresExistingMemberAttribute.cs
+++ b/src/SFA.DAS.Employer.Aan.Web/Filters/RequiresExistingMemberAttribute.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Filters;
+using SFA.DAS.Employer.Aan.Domain.Interfaces;
 using SFA.DAS.Employer.Aan.Web.Controllers;
 using SFA.DAS.Employer.Aan.Web.Extensions;
 
@@ -9,17 +10,28 @@ namespace SFA.DAS.Employer.Aan.Web.Filters;
 [ExcludeFromCodeCoverage]
 public class RequiresExistingMemberAttribute : ApplicationFilterAttribute
 {
-    public override void OnActionExecuting(ActionExecutingContext context)
+    private readonly ISessionService _sessionService;
+    private readonly IOuterApiClient _outerApiClient;
+
+    public RequiresExistingMemberAttribute(ISessionService sessionService, IOuterApiClient outerApiClient)
+    {
+        _sessionService = sessionService;
+        _outerApiClient = outerApiClient;
+    }
+
+    public override async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
     {
         if (context.ActionDescriptor is not ControllerActionDescriptor controllerActionDescriptor) return;
 
-        if (BypassCheck(controllerActionDescriptor)) return;
-
-        if (!IsValidRequest(context, controllerActionDescriptor))
+        var isValidRequest = await IsValidRequest(context, controllerActionDescriptor);
+        if (!isValidRequest)
         {
             context.RouteData.Values.TryGetValue("employerAccountId", out object? accountId);
             context.Result = RedirectToHome(new { EmployerAccountId = accountId });
+            return;
         }
+
+        await next();
     }
 
     private bool BypassCheck(ControllerActionDescriptor controllerActionDescriptor)
@@ -29,9 +41,19 @@ public class RequiresExistingMemberAttribute : ApplicationFilterAttribute
         return controllersToByPass.Contains(controllerActionDescriptor.ControllerTypeInfo.Name);
     }
 
-    private static bool IsValidRequest(ActionExecutingContext context, ControllerActionDescriptor controllerActionDescriptor)
+    private async Task<bool> IsValidRequest(ActionExecutingContext context, ControllerActionDescriptor controllerActionDescriptor)
     {
-        var isMember = context.HttpContext.User.GetAanMemberId() != Guid.Empty;
+        var sessionValue = _sessionService.Get(Constants.SessionKeys.MemberId);
+        if (sessionValue == null)
+        {
+            var response = await _outerApiClient.GetEmployerMember(context.HttpContext.User.GetUserId(), CancellationToken.None);
+            sessionValue = response.ResponseMessage.IsSuccessStatusCode ? response.GetContent().MemberId.ToString() : Guid.Empty.ToString();
+            _sessionService.Set(Constants.SessionKeys.MemberId, sessionValue);
+        }
+
+        if (BypassCheck(controllerActionDescriptor)) return true;
+
+        var isMember = Guid.Parse(sessionValue) != Guid.Empty;
 
         var isRequestingOnboardingPage = IsRequestForOnboardingAction(controllerActionDescriptor);
 

--- a/src/SFA.DAS.Employer.Aan.Web/Infrastructure/EmployerClaims.cs
+++ b/src/SFA.DAS.Employer.Aan.Web/Infrastructure/EmployerClaims.cs
@@ -9,5 +9,4 @@ public static class EmployerClaims
     public const string GivenName = "http://das/employer/identity/claims/given_name";
     public const string FamilyName = "http://das/employer/identity/claims/family_name";
     public static string Account => "http://das/employer/identity/claims/account";
-    public static string AanMemberId => "http://das/employer/identity/claims/aan_member_id";
 }

--- a/src/SFA.DAS.Employer.Aan.Web/Infrastructure/EmployerClaims.cs
+++ b/src/SFA.DAS.Employer.Aan.Web/Infrastructure/EmployerClaims.cs
@@ -3,9 +3,9 @@
 public static class EmployerClaims
 {
     public static string AccountsClaimsTypeIdentifier => "http://das/employer/identity/claims/associatedAccounts";
-    public static string IdamsUserIdClaimTypeIdentifier => "http://das/employer/identity/claims/id";
-    public static string IdamsUserDisplayNameClaimTypeIdentifier => "http://das/employer/identity/claims/display_name";
-    public static string IdamsUserEmailClaimTypeIdentifier => "http://das/employer/identity/claims/email_address";
+    public static string UserIdClaimTypeIdentifier => "http://das/employer/identity/claims/id";
+    public static string UserDisplayNameClaimTypeIdentifier => "http://das/employer/identity/claims/display_name";
+    public static string UserEmailClaimTypeIdentifier => "http://das/employer/identity/claims/email_address";
     public const string GivenName = "http://das/employer/identity/claims/given_name";
     public const string FamilyName = "http://das/employer/identity/claims/family_name";
     public static string Account => "http://das/employer/identity/claims/account";

--- a/src/SFA.DAS.Employer.Aan.Web/Infrastructure/Services/SessionService.cs
+++ b/src/SFA.DAS.Employer.Aan.Web/Infrastructure/Services/SessionService.cs
@@ -14,7 +14,7 @@ public class SessionService : ISessionService
     public void Set(string value, string key) => _httpContextAccessor.HttpContext?.Session.SetString(key, value);
     public void Set<T>(T model) => Set(JsonSerializer.Serialize(model), typeof(T).Name);
 
-    public string Get(string key) => _httpContextAccessor.HttpContext?.Session.GetString(key)!;
+    public string? Get(string key) => _httpContextAccessor.HttpContext?.Session.GetString(key);
 
     public T Get<T>()
     {

--- a/src/SFA.DAS.Employer.Aan.Web/Infrastructure/Services/SessionService.cs
+++ b/src/SFA.DAS.Employer.Aan.Web/Infrastructure/Services/SessionService.cs
@@ -11,8 +11,8 @@ public class SessionService : ISessionService
 
     public SessionService(IHttpContextAccessor httpContextAccessor) => _httpContextAccessor = httpContextAccessor;
 
-    public void Set(string value, string key) => _httpContextAccessor.HttpContext?.Session.SetString(key, value);
-    public void Set<T>(T model) => Set(JsonSerializer.Serialize(model), typeof(T).Name);
+    public void Set(string key, string value) => _httpContextAccessor.HttpContext?.Session.SetString(key, value);
+    public void Set<T>(T model) => Set(typeof(T).Name, JsonSerializer.Serialize(model));
 
     public string? Get(string key) => _httpContextAccessor.HttpContext?.Session.GetString(key);
 


### PR DESCRIPTION
Since the post authentication event does not fire at all at times, it was required to shift the memberId in to session. This has impact on any unmerged code and will require some refactoring after rebasing. 
I have also fixed missing authorization attribute on various controllers. This was mainly due to Auth functionality coming in later. We were meant to apply the auth attribute in retrospect but it was missed. 